### PR TITLE
Update langjin.js

### DIFF
--- a/langjin.js
+++ b/langjin.js
@@ -200,7 +200,7 @@ function 韻母規則() {
   // 梗攝
   if (is('庚韻 入聲 二等')) return is('合口') ? 'uä' : 'ä';
   if (is('庚韻 入聲 三等')) return is('莊組') ? 'ä' : is('合口') ? 'ü' : 'i';
-  if (is('庚韻 舒聲 二等')) return is('合口') ? 'uen' : 'en';
+  if (is('庚韻 舒聲 二等')) return is('合口') ? 'ong' : 'en';
   if (is('庚韻 舒聲 三等 合口')) return is('心以影母') ?  'in' : is('云影母') ? 'iong' : 'ong';
   if (is('庚韻 舒聲 三等 開口')) return is('知莊章組') ? 'en' : 'in';
   if (is('庚韻 舒聲 三等 幫組')) return 'in';


### PR DESCRIPTION
以ong爲合律之文讀，以uen爲出律之白讀。即《中原音韻》[uŋ]對[uəŋ]。推導音只收前者。

![de0bffc35cd39141e1933d48fdf9a3e0](https://github.com/user-attachments/assets/176b2f26-d843-472b-bde1-e8cc85222d35)
